### PR TITLE
docs: remove Node 18 mention in support checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 #### Documentation
 
 * [x] README states “pure maintenance upgrade” intent.
-* [ ] Document supported Node versions (22 now, 18/22 during transition).
+* [ ] Document supported Node versions (22 now).
 * [ ] Document core‑only scope, extension points, and public API surface (Config, Logger, BundleManager, EntityLoader, GameServer).
 * [ ] Document sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
 * [ ] Establish a lightweight changelog policy for maintenance releases (record user-visible changes and dependency/security actions).


### PR DESCRIPTION
### Motivation

* Align documentation with the current support policy by removing the historical Node 18 transition note and documenting Node 22 as the supported runtime.

### Description

* Update `README.md` maintenance checklist to replace the line `Document supported Node versions (22 now, 18/22 during transition)` with `Document supported Node versions (22 now)`; no code or behavior changes.

### Testing

* No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c935e5288326af5b33009dafb1b6)