### PR TITLE
Document removal of legacy lint configs before linting upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [x] CI installs via `npm ci`.
 * [x] CI currently runs on Node 22.
 * [x] Remove or update legacy `.travis.yml` (still targets Node 10).
-* [ ] Add a lint step or remove unused lint configs (`.eslintrc`, `.jshintrc`) to avoid confusion.
+* [ ] Upgrade linting to be usable locally and in CI (ESLint + Prettier) with fix scripts.
+  * Scope: remove legacy `.eslintrc`/`.jshintrc` first; start from a clean default ESLint/Prettier baseline.
+  * Scope: add `npm run lint` plus `npm run lint:fix` (auto-fix) for local use.
+  * Scope: add Prettier with `npm run format` and `npm run format:check` (or equivalent).
+  * Scope: lint `src/`, `test/`, and root JS entry files without changing exports.
+  * Scope: add `.git-blame-ignore-revs` for mechanical-only commits.
+  * Scope: wire CI to run lint/format checks only after formatting fixes land (avoid a failing baseline).
 
 #### Dependencies & Security Hygiene
 


### PR DESCRIPTION
### Motivation
- Clarify the linting checklist to require removing legacy `.eslintrc`/`.jshintrc` before introducing ESLint + Prettier so a clean default baseline and local fix/format tooling can be established without breaking CI.

### Description
- Update `README.md` to replace the previous lint checklist with a scoped upgrade checklist that explicitly requires removing legacy lint configs and adding `npm run lint`, `npm run lint:fix`, Prettier scripts, target paths (`src/`, `test/`, root JS entry files), `.git-blame-ignore-revs`, and CI sequencing guidance.

### Testing
- No automated tests were run because this is a documentation-only change; validation consisted of reviewing the updated `README.md` content for clarity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988cace35248326b6f223be9fb1ff13)