### PR TITLE
Update README checklist to remove npm packaging references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [ ] Fix `.npmignore` to include `README.md` (currently only `README.mkd` is whitelisted).
 * [ ] Add an explicit `files` whitelist in `package.json` (or equivalent) to ensure publish contents are correct and stable.
 * [ ] Document that `require-dir('./src/')` exposes all `src/*` modules as public API.
+* [ ] Remove npm packaging artifacts and references (e.g., `.npmignore`, `npm pack`, publish‑focused docs) since this repo is not distributed as an npm package.
 
 #### CI & Quality Gates
 
@@ -52,7 +53,6 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [x] Unit tests exist in `test/unit` for utility modules.
 * [ ] Add targeted tests for core subsystems (BundleManager, EntityLoader, registries, GameServer events).
 * [ ] Add coverage reporting/thresholds in CI (current CI runs tests only).
-* [ ] Add a lightweight `npm pack` smoke step to ensure publish artifacts are correct.
 
 #### Documentation
 


### PR DESCRIPTION
### Motivation
* Update the maintenance checklist to reflect that this repo is not distributed as an npm package and to remove publish-focused packaging steps.

### Description
* Edit `README.md` to add a checklist item to `Remove npm packaging artifacts and references (e.g., .npmignore, npm pack, publish‑focused docs)` and remove the prior `npm pack` smoke-step item from the Packaging & Distribution checklist.

### Testing
* No automated tests were run because this is a documentation-only change and validation is limited to a local file update of `README.md` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d123dd048326a9d987cb690896f0)