### PR TITLE
Remove obsolete .npmignore checklist item from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 
 * [x] `main` points to `index.js` (require‑dir export surface preserved).
 * [x] Entry point remains CommonJS and stable.
-* [ ] Fix `.npmignore` to include `README.md` (currently only `README.mkd` is whitelisted).
 * [ ] Add an explicit `files` whitelist in `package.json` (or equivalent) to ensure publish contents are correct and stable.
 * [ ] Document that `require-dir('./src/')` exposes all `src/*` modules as public API.
 * [ ] Remove npm packaging artifacts and references (e.g., `.npmignore`, `npm pack`, publish‑focused docs) since this repo is not distributed as an npm package.


### PR DESCRIPTION
### Motivation
- Remove an outdated checklist item that suggested fixing `.npmignore` to include `README.md` because it is no longer needed.

### Description
- Deleted the single checklist line in `README.md` that referenced fixing `.npmignore` to include `README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d36755808326bf3f76f2d37cb398)