### PR TITLE
Fix checklist checkbox for Node version doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 #### Documentation
 
 * [x] README states “pure maintenance upgrade” intent.
-* [ ] Document supported Node versions (22 now).
+* [x] Supported Node versions: Node 22 LTS (see `engines.node` and `.nvmrc`).
+* [x] Document supported Node versions (22 now).
 * [ ] Document core‑only scope, extension points, and public API surface (Config, Logger, BundleManager, EntityLoader, GameServer).
 * [ ] Document sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
 * [ ] Establish a lightweight changelog policy for maintenance releases (record user-visible changes and dependency/security actions).


### PR DESCRIPTION
### Motivation
- Ensure checklist consistency and address the inline review comment by converting the Node version line into a checked checklist item in `README.md`.

### Description
- Updated `README.md` to replace the non-checkbox list item `Supported Node versions: Node 22 LTS (see engines.node and .nvmrc)` with a checked checklist item and preserved the surrounding checklist structure.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d53b45b08326be0001572973a4a3)