### PR TITLE
Add docs/NOTES.md documenting public API export surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [x] `main` points to `index.js` (require‑dir export surface preserved).
 * [x] Entry point remains CommonJS and stable.
 * [ ] Add an explicit `files` whitelist in `package.json` (or equivalent) to ensure publish contents are correct and stable.
-* [ ] Document that `require-dir('./src/')` exposes all `src/*` modules as public API.
+* [x] Document in `docs/NOTES.md` that `require-dir('./src/')` exposes all `src/*` modules as public API.
 * [ ] Remove npm packaging artifacts and references (e.g., `.npmignore`, `npm pack`, publish‑focused docs) since this repo is not distributed as an npm package.
 
 #### CI & Quality Gates
@@ -58,9 +58,9 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [x] README states “pure maintenance upgrade” intent.
 * [x] Supported Node versions: Node 22 LTS (see `engines.node` and `.nvmrc`).
 * [x] Document supported Node versions (22 now).
-* [ ] Document core‑only scope, extension points, and public API surface (Config, Logger, BundleManager, EntityLoader, GameServer).
-* [ ] Document sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
-* [ ] Establish a lightweight changelog policy for maintenance releases (record user-visible changes and dependency/security actions).
+* [ ] Document in `docs/NOTES.md` the core‑only scope, extension points, and public API surface (Config, Logger, BundleManager, EntityLoader, GameServer).
+* [ ] Document in `docs/NOTES.md` sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
+* [ ] Establish in `docs/NOTES.md` a lightweight changelog policy for maintenance releases (record user-visible changes and dependency/security actions).
   * Scope: dependency upgrades/removals, runtime/CI changes, compatibility-impacting fixes, and removals of debugging hooks.
   * Format can be minimal (single `CHANGELOG.md` or “changelog entries in PR description”), but it must be consistent.
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,0 +1,5 @@
+# Notes
+
+## Public API surface
+
+The engine entrypoint uses `require-dir('./src/')`, which means every module under `src/` is part of the public API surface and should be treated as stable for downstream consumers.


### PR DESCRIPTION
### Motivation
- Centralize documentation about the engine export surface by recording that `require-dir('./src/')` exposes every `src/*` module as public API and satisfy the request to move the note into `docs/NOTES.md` while updating checklist references in `README.md`.

### Description
- Add `docs/NOTES.md` containing the public API note and update `README.md` checklist items to reference `docs/NOTES.md`; this is a documentation-only change that does not modify runtime code or exports and can be rolled back by reverting the commit.

### Testing
- No automated tests were run because this is a documentation-only change; CI configuration and test behavior were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d72bc0f883269af1443cd18b5312)