### PR TITLE
Remove packaging whitelist checklist item from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 
 * [x] `main` points to `index.js` (require‑dir export surface preserved).
 * [x] Entry point remains CommonJS and stable.
-* [ ] Add an explicit `files` whitelist in `package.json` (or equivalent) to ensure publish contents are correct and stable.
 * [x] Document in `docs/NOTES.md` that `require-dir('./src/')` exposes all `src/*` modules as public API.
 * [ ] Remove npm packaging artifacts and references (e.g., `.npmignore`, `npm pack`, publish‑focused docs) since this repo is not distributed as an npm package.
 


### PR DESCRIPTION
### Motivation
- Remove the checklist entry asserting a `files` whitelist in `package.json` because this repository is not published and the checklist item is irrelevant.

### Description
- Deleted the packaging checklist line from `README.md` under the "Packaging & Distribution" section (`README.md`).

### Testing
- No automated tests were run because this is a documentation-only change and has no runtime impact on CI or code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d99389cc8326b0a7fd2b0cba88b8)