### PR TITLE
Add changelog policy and initial changelog entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Every PR must include:
 - What changed and why
 - How it was validated (tests, manual steps)
 - Risks and rollback plan if applicable
+- Changelog entry updates per `docs/CHANGELOG_POLICY.md` and `CHANGELOG.md` when changes are user-visible, dependency/security-related, or represent intentional drifts from RanvierMUD behavior.
 
 ## Escalation rule for uncertainty
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All entries follow `docs/CHANGELOG_POLICY.md`.
+
+## Unreleased
+
+### Drift / Modernization
+- Summary:
+  - Replaced RanvierMUD's `sty` dependency with a homegrown color tag parser.
+- Why:
+  - Reduce dependency surface and align color parsing with engine-specific needs.
+- Impact:
+  - Downstream code that relied on `sty` behaviors should use the core color tag parser instead.
+- Migration/Action:
+  - Update downstream logging or formatting to use the core color tag format where applicable.
+- References:
+  - None.

--- a/docs/CHANGELOG_POLICY.md
+++ b/docs/CHANGELOG_POLICY.md
@@ -1,0 +1,62 @@
+# Changelog Policy (Maintenance Releases)
+
+This repository is a maintenance and stewardship fork of RanvierMUD. The changelog exists to document:
+- user-visible changes,
+- dependency and security actions,
+- runtime/CI changes, and
+- deliberate drifts or modernizations relative to the original RanvierMUD behavior or dependencies.
+
+The policy below is intentionally lightweight. It should be followed by maintainers, downstream game repo owners, bundle authors, and automated agents working on the core engine.
+
+## Canonical locations
+
+- **Policy:** `docs/CHANGELOG_POLICY.md` (this document).
+- **Entries:** `CHANGELOG.md` at the repo root.
+
+## When to add an entry
+
+Add or update a changelog entry when a change is:
+- user-visible (behavior changes, error handling, logging, diagnostics),
+- dependency or security related (upgrades, removals, vulnerability responses),
+- runtime/CI related (Node version support, build tooling, CI matrices),
+- compatibility-impacting (even if intended to be backward compatible),
+- a deliberate drift or modernization from RanvierMUD behavior or dependencies.
+
+## Required entry fields (per release or grouped change set)
+
+Each changelog entry must include:
+- **Summary:** short description of what changed.
+- **Why:** motivation or rationale (especially for drifts/modernizations).
+- **Impact:** who is affected and how (compatibility or operational impact).
+- **Migration/Action:** required steps for downstream users, or “None.”
+- **References:** relevant issues/PRs or commit identifiers if applicable.
+
+## Drift/modernization documentation
+
+When documenting drift from RanvierMUD, be explicit about:
+- the original RanvierMUD behavior or dependency,
+- the current behavior or replacement,
+- why the change was made,
+- any operational or compatibility implications.
+
+## Format (recommended)
+
+Use a simple, consistent structure in `CHANGELOG.md`:
+
+```
+## Unreleased
+
+### Drift / Modernization
+- Summary:
+  - ...
+- Why:
+  - ...
+- Impact:
+  - ...
+- Migration/Action:
+  - ...
+- References:
+  - ...
+```
+
+If a category has no changes, omit it. Keep entries short and scannable.


### PR DESCRIPTION
### Motivation
- Establish a lightweight changelog policy to document user-visible changes, dependency/security actions, CI/runtime changes, and deliberate drifts from RanvierMUD (e.g., replacing `sty` with a homegrown color tag parser).

### Description
- Add `docs/CHANGELOG_POLICY.md` with canonical locations, when to add entries, required fields, drift/modernization guidance, and a recommended format.
- Add root `CHANGELOG.md` with an `Unreleased` section and an initial `Drift / Modernization` entry describing the `sty` → core color tag parser change.
- Update `AGENTS.md` to require changelog entry updates per `docs/CHANGELOG_POLICY.md` for user-visible, dependency/security, or intentional drift changes.

### Testing
- No automated tests were run because this is a documentation-only change and does not affect runtime code or behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ecbe0e04832697b06896d622297c)