### PR TITLE
Mark sharp edges documentation task complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This checklist is scoped to the `Rantamuta/core` engine only. It focuses on a **
 * [x] Supported Node versions: Node 22 LTS (see `engines.node` and `.nvmrc`).
 * [x] Document supported Node versions (22 now).
 * [x] Document in `docs/NOTES.md` the core‑only scope, extension points, and public API surface (Config, Logger, BundleManager, EntityLoader, GameServer).
-* [ ] Document in `docs/NOTES.md` sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
+* [x] Document in `docs/NOTES.md` sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior).
 * [x] Establish in `docs/NOTES.md` a lightweight changelog policy for maintenance releases (record user-visible changes and dependency/security actions).
   * Scope: dependency upgrades/removals, runtime/CI changes, compatibility-impacting fixes, and removals of debugging hooks.
   * Format can be minimal (single `CHANGELOG.md` or “changelog entries in PR description”), but it must be consistent.


### PR DESCRIPTION
### Motivation
* The repository checklist indicated that `docs/NOTES.md` already documents sharp edges and failure modes, so the maintenance checklist should reflect that the item is complete.

### Description
* Update `README.md` to mark the checklist item "Document in `docs/NOTES.md` sharp edges and failure modes (Config load order, BundleManager exit paths, EventManager detach behavior)" as complete.

### Testing
* No automated tests were executed because this is a documentation-only change; no runtime code was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698906bc7ce083269a6121042a2634c7)