### PR TITLE
Add dependency audit documentation set

### DIFF
--- a/docs/dep-audit/01-inventory.md
+++ b/docs/dep-audit/01-inventory.md
@@ -1,0 +1,37 @@
+# Dependency Inventory
+
+## Direct dependencies (`package.json`)
+
+| Name | Version | Notes |
+| --- | --- | --- |
+| bcryptjs | ^2.4.0 | Runtime dependency. |
+| js-yaml | ^3.12.0 | Legacy candidate (README explicitly calls out js-yaml@3). |
+| longjohn | ^0.2.11 | README notes removal as a future task. |
+| pretty-error | ^2.0.2 | Used with `longjohn` in Logger pretty errors. |
+| require-dir | ^1.1.0 | Entry point export strategy relies on it. |
+| winston | ^2.4.4 | Legacy candidate (README explicitly calls out winston@2). |
+| wrap-ansi | ^2.0.0 | Legacy candidate (README explicitly calls out wrap-ansi@2). |
+
+## Dev dependencies (`package.json`)
+
+| Name | Version | Notes |
+| --- | --- | --- |
+| c8 | ^10.1.3 | Coverage tooling. |
+| coveralls-next | ^6.0.1 | Coverage reporter. |
+| mocha | ^10.5.0 | Test runner. |
+
+## Legacy candidates (explicit targets)
+
+| Dependency | Current version | Why flagged |
+| --- | --- | --- |
+| winston | ^2.4.4 | README calls out winston@2 as a legacy dependency. |
+| js-yaml | ^3.12.0 | README calls out js-yaml@3 as a legacy dependency. |
+| wrap-ansi | ^2.0.0 | README calls out wrap-ansi@2 as a legacy dependency. |
+
+## Transitive highlights (from `package-lock.json`)
+
+| Dependency | Version | Why highlighted |
+| --- | --- | --- |
+| glob | 8.1.0 | Deprecated in lockfile; also two major versions behind the glob 10.x line present elsewhere in the lockfile. |
+| inflight | 1.0.6 | Deprecated in lockfile with a warning about memory leaks. |
+| glob | 10.5.0 | Deprecated notice in lockfile (still marked as an old version). |

--- a/docs/dep-audit/02-usage-map.md
+++ b/docs/dep-audit/02-usage-map.md
@@ -1,0 +1,44 @@
+# Dependency Usage Map
+
+## winston
+
+**Import sites**
+- `src/Logger.js`: `const winston = require('winston');`
+
+**APIs used**
+- `winston.remove(winston.transports.Console)` and `winston.add(winston.transports.Console, { timestamp: true })` configure the default Console transport at module load.
+- `winston.level` is read/written via `Logger.getLevel()` and `Logger.setLevel()`.
+- `winston.log(level, ...messages)` is used for `log`, `error`, `warn`, and `verbose`.
+- `winston.add(winston.transports.File, { filename, timestamp: true })` is used for file logging; `winston.remove(winston.transports.File)` disables it.
+
+**Classification**
+- **Output-sensitive**: changes affect log output format/fields and runtime log behavior.
+- **Public-API-sensitive**: `Logger` is exported from `src/` and is part of the public API surface.
+- **Internal-only**: no (logs are externally visible).
+
+## js-yaml
+
+**Import sites**
+- `src/Data.js`: `const yaml = require('js-yaml');`
+
+**APIs used**
+- `yaml.load` parses `.yml` and `.yaml` files in `Data.parseFile`.
+- `yaml.safeDump` serializes `.yml` and `.yaml` files in `Data.saveFile`.
+
+**Classification**
+- **Data-format-sensitive**: YAML parsing/serialization directly impacts on-disk data.
+- **Public-API-sensitive**: `Data` is exported from `src/` and is part of the public API surface.
+- **Output-sensitive**: indirectly (output files and errors are visible to operators).
+
+## wrap-ansi
+
+**Import sites**
+- `src/Broadcast.js`: `const wrap = require('wrap-ansi');`
+
+**APIs used**
+- `wrap(ansi.parse(message), width)` is used in `Broadcast.wrap` to apply ANSI-aware wrapping after color parsing.
+
+**Classification**
+- **Output-sensitive**: wraps user-facing text written to sockets.
+- **Public-API-sensitive**: `Broadcast` is exported from `src/` and is part of the public API surface.
+- **Internal-only**: no (player-visible output is affected).

--- a/docs/dep-audit/03-invariants.md
+++ b/docs/dep-audit/03-invariants.md
@@ -1,0 +1,21 @@
+# Behavior Invariants (Must Not Change)
+
+## winston / Logger
+
+- **MUST** remove the default `Console` transport and re-add it with `timestamp: true` during Logger module initialization.
+- **MUST** keep `Logger.getLevel()` resolving in this order: `winston.level`, `process.env.LOG_LEVEL`, then `'debug'`.
+- **MUST** keep `Logger.log`, `Logger.error`, `Logger.warn`, and `Logger.verbose` delegating to `winston.log()` with their current log levels.
+- **MUST** keep `Logger.setFileLogging()` appending `.log` when missing and adding a File transport with `timestamp: true`.
+- **MUST** keep `Logger.deactivateFileLogging()` removing the File transport.
+
+## js-yaml / Data
+
+- **MUST** keep `Data.parseFile()` accepting `.yml`, `.yaml`, and `.json` only, throwing an error for missing files or unknown extensions.
+- **MUST** keep YAML parsing via `yaml.load` for `.yml`/`.yaml` and JSON parsing via `JSON.parse` for `.json`.
+- **MUST** keep `Data.saveFile()` writing YAML via `yaml.safeDump`, JSON via `JSON.stringify(data, null, 2)`, and throwing on missing files or unknown extensions.
+
+## wrap-ansi / Broadcast
+
+- **MUST** keep `Broadcast.at()` parsing color tags before writing to the socket (asserted by existing unit test).
+- **MUST** keep `Broadcast.wrap()` applying ANSI parsing before wrapping and normalizing newlines via `_fixNewlines`.
+- **MUST** keep `_fixNewlines()` normalizing lone `\n` into `\r\n` and stripping a trailing ANSI reset (`\x1B[0m`).

--- a/docs/dep-audit/04-options.md
+++ b/docs/dep-audit/04-options.md
@@ -1,0 +1,42 @@
+# Options Triage (No Decisions)
+
+## winston
+
+| Option | Notes | Risks tied to current usage |
+| --- | --- | --- |
+| Upgrade in place | Target winston v3 (current major). Requires validating `winston.transports.*` usage and log output formatting. | - Transport configuration APIs or defaults may have changed; Logger relies on `winston.transports.Console` and `winston.transports.File` with `timestamp: true`.
+- Log level handling (`winston.level` + `winston.log`) could change output or filtering.
+- Log output shape/fields could change and affect operator-facing logs. |
+| Replace | No clear drop-in replacement identified; Logger exposes a winston-shaped wrapper internally. | - Any replacement would need to reproduce existing log output to avoid behavior changes.
+- Changes to `Logger` internals risk breaking downstream usage of the public API. |
+| Remove | Implement a small internal logger only if usage surface is proven minimal. | - Re-implementing logging risks losing winston features used by operators (file logging, timestamps).
+- Output format changes could break scripts or expectations. |
+| Keep/pin | Retain winston v2 for now. | - Staying on an older major risks Node 22 compatibility issues and known ecosystem deprecations.
+- Delays needed modernization work while other deps move forward. |
+
+## js-yaml
+
+| Option | Notes | Risks tied to current usage |
+| --- | --- | --- |
+| Upgrade in place | Target js-yaml v4 (current major). Requires verifying `yaml.load` and `yaml.safeDump` API compatibility and output parity. | - `safeDump` is removed/renamed in newer majors, requiring call-site changes in `Data.saveFile`.
+- YAML output ordering or formatting changes could affect on-disk data diffs.
+- YAML parsing semantics may change for edge cases (schemas, tags). |
+| Replace | No clear drop-in replacement; alternatives (e.g., `yaml`) have different APIs and output behavior. | - Parser/serializer differences could alter data formats consumed by downstream bundles.
+- Requires more extensive regression tests for YAML round-trips. |
+| Remove | Only feasible if YAML support is dropped or re-implemented internally. | - Removing YAML support would be behavior-breaking for existing bundles and data files.
+- Re-implementation risk is high given YAML complexity. |
+| Keep/pin | Retain js-yaml v3 for now. | - Staying on an older major risks security and Node compatibility issues.
+- `safeDump` is already legacy API in newer js-yaml versions. |
+
+## wrap-ansi
+
+| Option | Notes | Risks tied to current usage |
+| --- | --- | --- |
+| Upgrade in place | Target the latest major (v7+). Validate wrapping behavior in `Broadcast.wrap`. | - ANSI wrapping behavior or default width handling could change, affecting player-visible output.
+- API signature or option defaults may differ in newer majors. |
+| Replace | No clear drop-in replacement; any alternative needs ANSI-aware wrapping parity. | - Differences in ANSI handling could break colorized output or alignment in game clients.
+- Replacement increases maintenance burden for a core output path. |
+| Remove | Implement a local wrapper only if matching current behavior is feasible. | - Custom wrapping logic may diverge from current behavior or mishandle ANSI sequences.
+- Risk of regressions in player-visible text formatting. |
+| Keep/pin | Retain wrap-ansi v2 for now. | - Staying on an older major risks Node compatibility and dependency ecosystem drift.
+- Blocks modernization of dependent tooling that expects newer wrap-ansi versions. |

--- a/docs/dep-audit/05-atomic-checklist.md
+++ b/docs/dep-audit/05-atomic-checklist.md
@@ -1,0 +1,25 @@
+# Atomic Follow-up Checklist (Draft)
+
+1. **Add unit tests for `Logger` behavior** (log level forwarding, file logging `.log` suffix, and transport usage).  
+   *Rationale:* Captures current winston integration before any upgrades.
+
+2. **Add YAML parse/save round‑trip tests for `Data.parseFile` / `Data.saveFile`.**  
+   *Rationale:* Locks in data serialization expectations for `.yml`/`.yaml` and `.json`.
+
+3. **Add unit tests for `Broadcast.wrap` output** (ANSI-aware wrapping and CRLF normalization).  
+   *Rationale:* Protects player-visible formatting before changing wrap-ansi.
+
+4. **Add a regression test to assert `Broadcast.at` color parsing behavior** (extend existing test with wrapWidth=false/true coverage).  
+   *Rationale:* Ensures color parsing stays stable with wrapping behavior changes.
+
+5. **Upgrade js-yaml from v3 to v4 and update `Data.saveFile` API usage** (`safeDump` → `dump`) in a dedicated PR after tests.  
+   *Rationale:* The usage surface is small and well-contained to `Data.js`.
+
+6. **Upgrade winston from v2 to v3 and adjust `Logger` transport configuration** with output‑format regression tests.  
+   *Rationale:* Logger is a narrow wrapper, but log output is externally visible.
+
+7. **Upgrade wrap-ansi from v2 to a current major and adjust `Broadcast.wrap` usage as needed.**  
+   *Rationale:* Single call site, but output formatting is player-visible and needs tests first.
+
+8. **Investigate transitive `glob@8` + `inflight` deprecations** (via c8/test-exclude) and propose a targeted dev dependency bump to eliminate deprecated transitive packages.  
+   *Rationale:* Keeps dev tooling free of deprecated dependencies without touching runtime behavior.


### PR DESCRIPTION
### Motivation
- Provide an evidence-backed baseline for dependency modernization without changing runtime behavior.
- Surface explicit legacy candidates (`winston@2`, `js-yaml@3`, `wrap-ansi@2`) and noteworthy transitive items for triage.
- Produce small, actionable follow-ups (tests and dedicated upgrade PRs) so upgrades remain atomic and reversible.

### Description
- Add a documentation set under `docs/dep-audit/` (`01-inventory.md`, `02-usage-map.md`, `03-invariants.md`, `04-options.md`, `05-atomic-checklist.md`) that inventories direct/dev deps, highlights legacy/transitive candidates, maps code usage, and records behavior invariants. This is documentation-only and does not modify runtime code or lockfiles.  
- Key repo observations captured: `src/Logger.js` uses `winston` transports and `winston.log`; `src/Data.js` uses `js-yaml` (`load`/`safeDump`); `src/Broadcast.js` uses `wrap-ansi` via `wrap(ansi.parse(...), width)`; `package-lock.json` contains deprecated transitive packages (`glob`, `inflight`).  
- Includes an options triage for each legacy candidate and an atomic checklist enumerating small PR-sized follow-ups (tests first, then dedicated upgrade PRs).  
- Risks & rollback: documentation-only change with low risk; rollback is removal of the new docs files if needed.

### Testing
- No automated tests were executed for this change because it is documentation-only and does not alter code paths or dependencies.  
- Validation performed: repository inspection (searches in `src/`, `test/`, and `package-lock.json`) to ground assertions in code locations referenced by the docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989963b9a14832693854f3681acd0e7)