### PR TITLE
Add validation-rule unit tests for DataSourceRegistry and EntityLoaderRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These items are intentionally **post-1.0**. They remain within the Rantamuta ste
 
 ### DX & Maintainability
 
-* [ ] Add unit tests for `DataSourceRegistry.load` and `EntityLoaderRegistry.load` validation rules.
+* [x] Add unit tests for `DataSourceRegistry.load` and `EntityLoaderRegistry.load` validation rules.
 * [ ] Add unit tests for `EntityLoader` method gating and error messages.
 * [ ] Add tests for `BundleManager.loadBundles(distribute=false)` and `_getLoader` compatibility.
 * [ ] Add tests for `EventManager.attach` / `detach` semantics and the `removeAllListeners` warning edge.

--- a/test/unit/RegistryValidation.js
+++ b/test/unit/RegistryValidation.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+
+const DataSourceRegistry = require('../../src/DataSourceRegistry');
+const EntityLoaderRegistry = require('../../src/EntityLoaderRegistry');
+const EntityLoader = require('../../src/EntityLoader');
+
+describe('Registry validation rules', () => {
+  describe('DataSourceRegistry.load', () => {
+    it("throws when a datasource is missing 'require'", () => {
+      const registry = new DataSourceRegistry();
+
+      assert.throws(() => registry.load(() => ({}), process.cwd(), {
+        players: {}
+      }), /DataSource \[players\] does not specify a 'require'/);
+    });
+
+    it("throws when a datasource has a non-string 'require'", () => {
+      const registry = new DataSourceRegistry();
+
+      assert.throws(() => registry.load(() => ({}), process.cwd(), {
+        players: { require: 42 }
+      }), /DataSource \[players\] has an invalid 'require'/);
+    });
+
+    it("throws when datasource instance does not implement hasData", () => {
+      const registry = new DataSourceRegistry();
+      const requireFn = () => ({
+        InMemoryDataSource: class {}
+      });
+
+      assert.throws(() => registry.load(requireFn, process.cwd(), {
+        players: { require: 'data-source-module.InMemoryDataSource' }
+      }), /Data Source players requires at minimum a 'hasData\(config\): boolean' method/);
+    });
+  });
+
+  describe('EntityLoaderRegistry.load', () => {
+    it("throws when an entity loader is missing 'source'", () => {
+      const sourceRegistry = new Map();
+      const registry = new EntityLoaderRegistry();
+
+      assert.throws(() => registry.load(sourceRegistry, {
+        areas: {}
+      }), /EntityLoader \[areas\] does not specify a 'source'/);
+    });
+
+    it("throws when an entity loader has a non-string 'source'", () => {
+      const sourceRegistry = new Map();
+      const registry = new EntityLoaderRegistry();
+
+      assert.throws(() => registry.load(sourceRegistry, {
+        areas: { source: 99 }
+      }), /EntityLoader \[areas\] has an invalid 'source'/);
+    });
+
+    it('throws when an entity loader references an unknown data source', () => {
+      const sourceRegistry = new Map();
+      const registry = new EntityLoaderRegistry();
+
+      assert.throws(() => registry.load(sourceRegistry, {
+        areas: { source: 'missingSource' }
+      }), /Invalid source \[missingSource\] for entity \[areas\]/);
+    });
+
+    it('creates EntityLoader instances for valid config', () => {
+      const source = { hasData: () => true };
+      const sourceRegistry = new Map([['json', source]]);
+      const registry = new EntityLoaderRegistry();
+
+      registry.load(sourceRegistry, {
+        areas: {
+          source: 'json',
+          config: { path: '/tmp/areas' }
+        }
+      });
+
+      const loader = registry.get('areas');
+      assert.ok(loader instanceof EntityLoader);
+      assert.strictEqual(loader.dataSource, source);
+      assert.deepStrictEqual(loader.config, { path: '/tmp/areas' });
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

* Lock in current validation behavior for data/loader registries so future changes cannot silently alter contracts that downstream bundles rely on.
* This advances the v1.1 maintenance checklist with a small, low-risk test addition that does not change production code.

### Description

* Add a new test suite `test/unit/RegistryValidation.js` that asserts `DataSourceRegistry.load` rejects configs missing `require`, rejects non-string `require`, and requires loader instances to implement `hasData`, and that `EntityLoaderRegistry.load` rejects missing/invalid `source`, rejects unknown sources, and constructs `EntityLoader` for valid config. 
* Mark the corresponding checklist item in `README.md` as complete (`* [x] Add unit tests for DataSourceRegistry.load and EntityLoaderRegistry.load validation rules.`).

### Testing

* Ran `npm test` which executed the full unit suite including the new tests and completed successfully (`50 passing`).
* Ran `npm run ci:local` which failed because the project does not define a `ci:local` script (error: `Missing script: "ci:local"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8513c2508326a5b639a14b87b941)