### PR TITLE
fix(effect-factory): resolve get() recursion stack overflow (#49)

### DIFF
--- a/src/EffectFactory.js
+++ b/src/EffectFactory.js
@@ -49,7 +49,8 @@ class EffectFactory {
    * @return {object}
    */
   get(id) {
-    return this.get(id);
+    const entry = this.effects.get(id);
+    return entry ? entry.definition : null;
   }
 
   /**

--- a/test/unit/EffectFactory.js
+++ b/test/unit/EffectFactory.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+
+const EffectFactory = require('../../src/EffectFactory');
+
+describe('EffectFactory', () => {
+  describe('#get', () => {
+    it('returns a registered effect definition by id', () => {
+      const factory = new EffectFactory();
+      factory.add('burn', {
+        config: { name: 'Burning' },
+        state: { stacks: 1 },
+        listeners: {},
+      });
+
+      const definition = factory.get('burn');
+
+      assert.deepStrictEqual(definition, {
+        config: { name: 'Burning' },
+        state: { stacks: 1 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What changed and why

This PR fixes issue #49 (`FactoryGetRecursion`).

`EffectFactory#get` in `src/EffectFactory.js` recursively called itself, causing a stack overflow (`RangeError: Maximum call stack size exceeded`) on any lookup.  
The method now returns the registered definition from `this.effects` (or `null` when missing), which matches the method’s documented intent.

## Implementation details

- Updated `src/EffectFactory.js`:
- `get(id)` now:
- reads `const entry = this.effects.get(id);`
- returns `entry ? entry.definition : null`

- Added regression test `test/unit/EffectFactory.js`:
- verifies `factory.get('burn')` returns the expected definition object
- reproduces the previous failure before the fix
- passes after the fix

## Validation

Executed:
- `npx mocha test/unit/EffectFactory.js`

Result:
- `1 passing`
- confirmed prior recursion failure is resolved

## Risks

- Low risk.
- Behavior change is limited to `EffectFactory#get` and aligns with existing docs/comments.
- No entrypoint/export-surface changes.

## Rollback plan

- Revert this PR commit to restore previous behavior.

## Changelog

- Recommend adding a patch-level bugfix entry for issue #49 (`EffectFactory#get` stack overflow fix).

