### PR TITLE
fix(attribute-factory): honor explicit base=0 override in create() (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,22 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
   - Tests: `test/unit/Attribute.js` (`#constructor` strict validation coverage)
 - Timestamp: 2026.02.17 16:32
 
+### AttributeFactory.create explicit zero-base override fix
+
+- Summary:
+  - Fixed `AttributeFactory.create()` to respect explicit `base = 0` overrides instead of falling back to definition defaults.
+- Why:
+  - `create()` previously used `base || def.base`, which treated `0` as missing and produced incorrect base values.
+- Impact:
+  - `create(name, 0)` now correctly produces attributes with base `0`.
+  - `null`/`undefined` base inputs still fall back to the definition base.
+- Migration/Action:
+  - None.
+- References:
+  - Issue: #63
+  - Tests: `test/unit/AttributeFactory.js` (`#create base override` coverage)
+- Timestamp: 2026.02.17 16:40
+
 ### Strict mode duplicate registration enforcement
 
 - Summary:

--- a/src/AttributeFactory.js
+++ b/src/AttributeFactory.js
@@ -67,7 +67,8 @@ class AttributeFactory {
     }
 
     const def = this.attributes.get(name);
-    return new Attribute(name, base || def.base, delta, def.formula, cloneMetadata(def.metadata));
+    const resolvedBase = (base === null || base === undefined) ? def.base : base;
+    return new Attribute(name, resolvedBase, delta, def.formula, cloneMetadata(def.metadata));
   }
 
   /**

--- a/test/unit/AttributeFactory.js
+++ b/test/unit/AttributeFactory.js
@@ -29,6 +29,32 @@ describe('AttributeFactory', () => {
     });
   });
 
+  describe('#create base override', () => {
+    it('respects an explicit base override of 0', () => {
+      const factory = new AttributeFactory();
+      factory.add('health', 100);
+
+      const attr = factory.create('health', 0);
+      assert.strictEqual(attr.base, 0);
+    });
+
+    it('uses definition base when base override is null', () => {
+      const factory = new AttributeFactory();
+      factory.add('health', 100);
+
+      const attr = factory.create('health', null);
+      assert.strictEqual(attr.base, 100);
+    });
+
+    it('uses definition base when base override is undefined', () => {
+      const factory = new AttributeFactory();
+      factory.add('health', 100);
+
+      const attr = factory.create('health', undefined);
+      assert.strictEqual(attr.base, 100);
+    });
+  });
+
   describe('#validateAttributes', () => {
     function makeFactory() {
       return new AttributeFactory();


### PR DESCRIPTION
## What changed and why

closes issue #63

`AttributeFactory.create()` treated `base = 0` as missing due to `base || def.base` fallback logic.
This PR fixes that correctness bug by using explicit nullish handling.

## Changes

- `test/unit/AttributeFactory.js`
- Added `#create base override` regression tests:
  - explicit `base = 0` is respected
  - `base = null` falls back to definition base
  - `base = undefined` falls back to definition base

- `src/AttributeFactory.js`
- Replaced `base || def.base` with explicit nullish resolution:
  - `const resolvedBase = (base === null || base === undefined) ? def.base : base;`

- `CHANGELOG.md`
- Added Unreleased entry for issue #63

## Validation

- `npx mocha test/unit/AttributeFactory.js` (9 passing)

## Risks

- Low and localized to attribute creation base resolution.
- Behavior is corrected for explicit zero overrides; null/undefined fallback remains unchanged.
