### PR TITLE
fix(command-manager): remove alias keys when removing a command (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,23 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
   - Tests: `test/unit/AttributeFactory.js` (`#create base override` coverage)
 - Timestamp: 2026.02.17 16:40
 
+### CommandManager alias cleanup on remove
+
+- Summary:
+  - Fixed `CommandManager.remove(command)` to remove alias keys registered for the command, not just `command.name`.
+  - Added safe guards so keys are removed only if they still resolve to the same command instance.
+- Why:
+  - Removing only the canonical command name left stale aliases registered and still resolvable.
+- Impact:
+  - Removed commands no longer remain reachable through stale aliases.
+  - Alias keys reassigned to another command are preserved.
+- Migration/Action:
+  - None.
+- References:
+  - Issue: #39
+  - Tests: `test/unit/CommandManager.js` (`remove` alias cleanup coverage)
+- Timestamp: 2026.02.17 16:44
+
 ### Strict mode duplicate registration enforcement
 
 - Summary:

--- a/src/CommandManager.js
+++ b/src/CommandManager.js
@@ -32,7 +32,17 @@ class CommandManager {
    * @param {Command}
    */
   remove(command) {
-    this.commands.delete(command.name);
+    if (this.commands.get(command.name) === command) {
+      this.commands.delete(command.name);
+    }
+
+    if (command.aliases) {
+      command.aliases.forEach(alias => {
+        if (this.commands.get(alias) === command) {
+          this.commands.delete(alias);
+        }
+      });
+    }
   }
 
   /**

--- a/test/unit/CommandManager.js
+++ b/test/unit/CommandManager.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+const CommandManager = require('../../src/CommandManager');
+
+describe('CommandManager', () => {
+  it('remove(command) removes alias keys for that command', () => {
+    const manager = new CommandManager();
+    const command = { name: 'look', aliases: ['l', 'lo'] };
+
+    manager.add(command);
+    manager.remove(command);
+
+    assert.strictEqual(manager.get('look'), undefined);
+    assert.strictEqual(manager.get('l'), undefined);
+    assert.strictEqual(manager.get('lo'), undefined);
+  });
+
+  it('remove(command) does not remove alias keys now bound to a different command', () => {
+    const manager = new CommandManager();
+    const first = { name: 'look', aliases: ['l'] };
+    const second = { name: 'list', aliases: ['l'] };
+
+    manager.add(first);
+    manager.add(second);
+    manager.remove(first);
+
+    assert.strictEqual(manager.get('l'), second);
+  });
+});


### PR DESCRIPTION
## What changed and why

closes issue #39

`CommandManager.remove(command)` deleted only `command.name` and left alias keys behind.
This caused removed commands to remain reachable through stale aliases.

## Changes

- `test/unit/CommandManager.js`
- Added regression tests that verify:
  - removing a command removes its alias keys
  - alias keys rebound to a different command are not removed

- `src/CommandManager.js`
- Updated `remove(command)` to:
  - remove `command.name` only if it still points to `command`
  - remove each alias only if it still points to `command`

- `CHANGELOG.md`
- Added Unreleased entry for issue #39

## Validation

- `npx mocha test/unit/CommandManager.js` (2 passing)

## Risks

- Low and localized to command removal behavior.
- Fix removes stale alias registrations while preserving alias keys reassigned to other commands.
