### PR TITLE
fix(bundle-manager): warn when startup loads zero bundles (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,22 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
   - Tests: `test/unit/CommandManager.js` (`remove` alias cleanup coverage)
 - Timestamp: 2026.02.17 16:44
 
+### BundleManager no-bundles startup warning
+
+- Summary:
+  - Added an explicit startup warning when bundle loading completes with zero bundles loaded.
+- Why:
+  - Startup could appear to hang or proceed silently when no bundles were configured/loadable, making root cause discovery slow.
+- Impact:
+  - On no-bundles startup, logs now include a warning with configured bundle list and bundle path.
+  - Startup behavior is otherwise unchanged (warning-only; no forced throw).
+- Migration/Action:
+  - If warning appears, verify `Config.bundles` and bundle directory contents/path.
+- References:
+  - Issue: #34
+  - Tests: `test/unit/BundleManagerWarnings.js` (`warns when no bundles are configured or loadable during startup`)
+- Timestamp: 2026.02.17 17:04
+
 ### Strict mode duplicate registration enforcement
 
 - Summary:

--- a/src/BundleManager.js
+++ b/src/BundleManager.js
@@ -52,6 +52,7 @@ class BundleManager {
 
     const configuredBundles = this.state.Config.get('bundles', []);
     const seenBundles = new Set();
+    let loadedBundleCount = 0;
 
     for (const bundle of configuredBundles) {
       if (seenBundles.has(bundle)) {
@@ -76,6 +77,12 @@ class BundleManager {
       }
 
       await this.loadBundle(bundle, bundlePath);
+      loadedBundleCount++;
+    }
+
+    if (!loadedBundleCount) {
+      const configuredList = configuredBundles.length ? configuredBundles.join(', ') : '(none)';
+      Logger.warn(`No bundles were loaded. Configured bundles: [${configuredList}]. Bundle path: [${this.bundlesPath}]`);
     }
 
     try {


### PR DESCRIPTION
## What changed and why

closes issue #34

When no bundles were configured/loadable, startup logs could proceed without an explicit signal, which made diagnosis slow.
This PR adds a warning-only diagnostic when zero bundles are loaded.

## Changes

- `test/unit/BundleManagerWarnings.js`
- Added regression test asserting a warning is emitted when no bundles are configured/loadable during `loadBundles(false)`

- `src/BundleManager.js`
- In `loadBundles(...)`, track how many bundles were successfully loaded
- If zero bundles are loaded, emit warning with:
  - configured bundle list
  - bundle path

- `CHANGELOG.md`
- Added Unreleased entry for issue #34

## Validation

- `npx mocha test/unit/BundleManagerWarnings.js` (5 passing)
- `npx mocha test/unit/BundleManagerLoadOrder.js` (2 passing)

## Risks

- Low and localized to startup logging.
- Behavior is warning-only; no new throw/exit paths were introduced.
