### PR TITLE
fix(player): recover missing room data during hydrate (closes #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
 
 ## Unreleased
 
+### Player missing-room hydrate recovery
+
+- Summary:
+  - Updated `Player#hydrate` to repair players saved with missing/null `room` by moving them to the placeholder room.
+  - Added explicit error logging when a player is saved without a room.
+- Why:
+  - Missing/null room data left players in an invalid "nowhere" state and could lead to save failures with unclear diagnostics.
+- Impact:
+  - Players with missing/null `room` values are now recovered during hydrate instead of remaining roomless.
+  - Operators now receive an explicit error log for this data corruption case.
+- Migration/Action:
+  - None.
+- References:
+  - Issue: #31
+  - Tests: `test/unit/PlayerHydrateRoom.js` (`Player hydrate room recovery` coverage)
+- Timestamp: 2026.02.17 17:15
+
 ### EffectFactory.get recursion fix
 
 - Summary:

--- a/src/Player.js
+++ b/src/Player.js
@@ -205,7 +205,12 @@ class Player extends Character {
       this.equipment = new Map();
     }
 
-    if (typeof this.room === 'string') {
+    if (this.room === null) {
+      Logger.error(`ERROR: Player ${this.name} was saved without a room.`);
+      const room = state.AreaManager.getPlaceholderArea().getRoomById('placeholder');
+      this.room = room;
+      this.moveTo(room);
+    } else if (typeof this.room === 'string') {
       let room = state.RoomManager.getRoom(this.room);
       if (!room) {
         Logger.error(`ERROR: Player ${this.name} was saved to invalid room ${this.room}.`);

--- a/test/unit/PlayerHydrateRoom.js
+++ b/test/unit/PlayerHydrateRoom.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const Logger = require('../../src/Logger');
+const Player = require('../../src/Player');
+
+function makeRoom(entityReference) {
+  const room = new EventEmitter();
+  room.entityReference = entityReference;
+  room.players = new Set();
+  room.addPlayer = player => room.players.add(player);
+  room.removePlayer = player => room.players.delete(player);
+  return room;
+}
+
+function makeState(placeholderRoom) {
+  return {
+    AreaManager: {
+      getPlaceholderArea: () => ({
+        getRoomById: id => {
+          assert.strictEqual(id, 'placeholder');
+          return placeholderRoom;
+        },
+      }),
+    },
+    RoomManager: {
+      getRoom: () => null,
+    },
+  };
+}
+
+function makePlayer(data = {}) {
+  return new Player(Object.assign({
+    name: 'Tester',
+    password: 'secret',
+    inventory: {
+      max: 5,
+      items: [],
+    },
+    quests: {
+      active: [],
+      completed: [],
+    },
+    effects: [],
+    equipment: new Map(),
+  }, data));
+}
+
+describe('Player hydrate room recovery', () => {
+  let originalError;
+
+  beforeEach(() => {
+    originalError = Logger.error;
+  });
+
+  afterEach(() => {
+    Logger.error = originalError;
+  });
+
+  it('repairs null room to placeholder room and logs an error', () => {
+    const placeholderRoom = makeRoom('placeholder:placeholder');
+    const player = makePlayer({ room: null });
+    const errors = [];
+
+    Logger.error = (...args) => errors.push(args.join(' '));
+
+    player.hydrate(makeState(placeholderRoom));
+
+    assert.strictEqual(player.room, placeholderRoom);
+    assert.strictEqual(placeholderRoom.players.has(player), true);
+    assert.strictEqual(errors.length > 0, true);
+  });
+
+  it('repairs missing room to placeholder room and logs an error', () => {
+    const placeholderRoom = makeRoom('placeholder:placeholder');
+    const player = makePlayer();
+    const errors = [];
+
+    Logger.error = (...args) => errors.push(args.join(' '));
+
+    player.hydrate(makeState(placeholderRoom));
+
+    assert.strictEqual(player.room, placeholderRoom);
+    assert.strictEqual(placeholderRoom.players.has(player), true);
+    assert.strictEqual(errors.length > 0, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for players loaded with `room: null` or missing `room`
- repair missing/null room values during `Player#hydrate` by moving affected players to the placeholder room
- log an explicit error when a player is saved without a room
- add changelog entry per policy

closes issue #31

## Validation
- `npx mocha test/unit/PlayerHydrateRoom.js`
- `npm test`

## Risks
- behavior change only affects corrupted player data where `room` is null/missing
- recovered players are placed in placeholder room (same recovery strategy used for invalid room references)

## Rollback
- revert commits on `fix-31`:
  - `Test issue 31`
  - `Fix issue 31`
  - `Log issue 31 fix`
