### PR TITLE
fix(bundle-manager): add actionable missing quests.yml diagnostics (closes #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All entries follow `docs/CHANGELOG_POLICY.md`.
 
 ## Unreleased
 
+### Missing quests.yml diagnostics hardening
+
+- Summary:
+  - Improved `BundleManager#loadQuests` error messaging for missing `quests.yml` files by including contract guidance and the expected file path.
+  - Added README guidance that questless areas must still include `quests.yml` containing `[]`.
+- Why:
+  - Startup failures from missing `quests.yml` were fail-fast but not sufficiently actionable for maintainers.
+- Impact:
+  - Boot behavior remains fail-fast for missing quest files.
+  - Operators now get explicit remediation instructions in the thrown/logged error for `ENOENT` quest-load failures.
+- Migration/Action:
+  - Ensure every area includes `areas/<area>/quests.yml`.
+  - For questless areas, create `quests.yml` with `[]`.
+- References:
+  - Issue: #77
+  - Tests: `test/unit/BundleManager.js` (`adds actionable guidance when quests.yml is missing`)
+- Timestamp: 2026.02.17 17:20
+
 ### Player missing-room hydrate recovery
 
 - Summary:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Install dependencies with `npm ci` and run tests with `npm test`.
 
 CI (GitHub Actions) runs on Node 22, installs with `npm ci`, runs `npm test`, and publishes a non-blocking `npm audit` report.
 
+## Bundle Area Quest Contract
+
+Each bundle area must include `areas/<area>/quests.yml`.
+
+If an area has no quests, keep the file and set its contents to:
+
+```yaml
+[]
+```
+
+`BundleManager` treats a missing `quests.yml` as a load error by contract.
+
 ## Version lineage and compatibility
 
 Rantamuta `v1.0.0` is a maintenance fork of RanvierMUD, cut at RanvierMUD `v3.0.6`.

--- a/test/unit/BundleManager.js
+++ b/test/unit/BundleManager.js
@@ -49,6 +49,71 @@ describe('BundleManager', () => {
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     });
+
+    it('adds actionable guidance when quests.yml is missing', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-manager-'));
+      const missingPath = path.join(
+        tempDir,
+        'example-bundle',
+        'areas',
+        'example-area',
+        'quests.yml'
+      );
+      const missingErr = new Error(`ENOENT: no such file or directory, open '${missingPath}'`);
+      missingErr.code = 'ENOENT';
+      missingErr.path = missingPath;
+
+      const loader = {
+        setBundle: () => {},
+        setArea: () => {},
+        fetchAll: async () => {
+          throw missingErr;
+        }
+      };
+      const state = {
+        EntityLoaderRegistry: {
+          get: () => loader
+        },
+        QuestFactory: {
+          add: () => {
+            throw new Error('QuestFactory.add should not be called');
+          },
+          makeQuestKey: () => 'unused'
+        }
+      };
+
+      await withStubbedLoggerError(async errorCalls => {
+        const manager = new BundleManager(tempDir, state);
+
+        await assert.rejects(
+          () => manager.loadQuests('example-bundle', 'example-area'),
+          error => {
+            assert.match(
+              error.message,
+              /quests\.yml is required for each area/
+            );
+            assert.match(
+              error.message,
+              /For areas with no quests, create quests\.yml containing \[\]/
+            );
+            assert.match(
+              error.message,
+              /example-bundle\/areas\/example-area\/quests\.yml/
+            );
+            assert.strictEqual(error.cause, missingErr);
+            return true;
+          }
+        );
+
+        assert.strictEqual(errorCalls.length, 1);
+        assert.match(
+          String(errorCalls[0][0]),
+          /quests\.yml is required for each area/
+        );
+      });
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
   });
 });
 

--- a/test/unit/BundleManager.js
+++ b/test/unit/BundleManager.js
@@ -98,7 +98,7 @@ describe('BundleManager', () => {
             );
             assert.match(
               error.message,
-              /example-bundle\/areas\/example-area\/quests\.yml/
+              /example-bundle[\\/]+areas[\\/]+example-area[\\/]+quests\.yml/
             );
             assert.strictEqual(error.cause, missingErr);
             return true;


### PR DESCRIPTION
## Summary
- add regression coverage for missing `quests.yml` handling in `BundleManager#loadQuests`
- preserve fail-fast behavior but make missing-file failures actionable by including:
  - expected `quests.yml` path
  - contract requirement that each area must include `quests.yml`
  - guidance for questless areas: create file with `[]`
- document the same quest-file contract in `README.md`
- add changelog entry per policy

closes issue #77

## Validation
- `npx mocha test/unit/BundleManager.js`
- `npm test`

## Risks
- no semantic change for successful loads
- non-`ENOENT` quest-load failures keep existing error shape
- `ENOENT` quest-load failures now include additional guidance text in log/thrown message

## Rollback
- revert commits on `fix-77`:
  - `Test issue 77`
  - `Fix issue 77`
  - `Log issue 77 fix`
